### PR TITLE
SB-1162: Fix sequelize sync on models w/ associations

### DIFF
--- a/factories/sequelize.js
+++ b/factories/sequelize.js
@@ -66,7 +66,7 @@ module.exports = (
 			}
 		})
 
-		await Sequelize.Promise.each(filteredModels, model => model.sync())
+		await sequelize.sync()
 
 		// Run migrations if enabled
 		if (runMigrations && fs.existsSync(migrationsDir)) {


### PR DESCRIPTION
[SB-1162](https://jira.sprucelabs.ai/jira/browse/SB-1162)

@sprucelabsai/engineers

## Description 
Runs ```sequelize.sync()``` which syncs all imported models.

This is instead of running ```.sync()``` on each model, which doesn't take into account associations and just blindly tries to sync.  Depending on the order the models are sync'd this can cause associations to fail.

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt

## Steps to Test or Reproduce

* Create 2 models (ModelA, ModelB) in a skill w/ a DB

* Create a ```belongsTo``` association from ModelA to ModelB

* Run skill

**Result: ** Skill fails to boot complaining that the relation does not exist

**Expected Result: ** Skill boots and associations are created